### PR TITLE
Added extra variable for blade subdirectory views and  templates

### DIFF
--- a/src/dam1r89/ProtoGenerator/ContextDataParser.php
+++ b/src/dam1r89/ProtoGenerator/ContextDataParser.php
@@ -63,6 +63,7 @@ class ContextDataParser implements ContextDataParserInterface{
         $controller = Ucfirst($collection);
 
         $item = str_singular($collection);
+        $itemLower = strtolower($item);
         $model = Ucfirst($item);
         $migrationDate = $this->getDatePrefix();
 
@@ -72,7 +73,7 @@ class ContextDataParser implements ContextDataParserInterface{
             $fields[] = new Field($name, $field);
         }
 
-        return compact('table', 'item', 'singleItem', 'model', 'controller', 'collection', 'migrationDate', 'fields');
+        return compact('table', 'item', 'itemLower', 'singleItem', 'model', 'controller', 'collection', 'migrationDate', 'fields');
     }
 
     protected function getDatePrefix()

--- a/tests/ContextDataParserTest.php
+++ b/tests/ContextDataParserTest.php
@@ -32,6 +32,7 @@ class ContextDataParserTest extends PHPUnit_Framework_TestCase{
         $this->assertEquals('cars', $data['collection']);
         $this->assertEquals('Cars', $data['controller']);
         $this->assertEquals('car', $data['item']);
+        $this->assertEquals('car', $data['itemLower']);
         $this->assertEquals('Car', $data['model']);
 
     }
@@ -61,6 +62,7 @@ class ContextDataParserTest extends PHPUnit_Framework_TestCase{
         $this->assertEquals('videoTags', $data['collection']);
         $this->assertEquals('VideoTags', $data['controller']);
         $this->assertEquals('videoTag', $data['item']);
+        $this->assertEquals('videotag', $data['itemLower']);
         $this->assertEquals('VideoTag', $data['model']);
     }
 


### PR DESCRIPTION
Hi, Thanks for building this. This is a fantastic replacement for the "Way Generators" that did not get updated for Laravel 5.  

I ran into some issues with table names like "this_is_a_table_name" and how the view blade subdirectory name was being generated.  As I am using my own custom templates I just added an extra variable to support this situation.  Posting this back upstream so hopefully I don't have to keep maintaining a  forked version.

Thanks!
